### PR TITLE
Fixing div overflow that causes horizontal scroll

### DIFF
--- a/components/ProgressRing.vue
+++ b/components/ProgressRing.vue
@@ -36,7 +36,7 @@ const color = computed(() => {
 
 <template>
   <span class="flex flex-col items-center" :class="size === 'large' ? 'gap-10' : 'gap-4'">
-    <span class="relative rounded-full flex items-center justify-center" :class="[size === 'large' ? 'text-7xl h-60 w-60' : 'text-3xl h-36 w-36', color]">
+    <span class="relative rounded-full flex items-center justify-center overflow-hidden" :class="[size === 'large' ? 'text-7xl h-60 w-60' : 'text-3xl h-36 w-36', color]">
       <svg class="absolute -right-0 -bottom-0" :height="radius * 2" :width="radius * 2" :class="{ 'animate-spin': !value }">
         <circle
           stroke="currentColor"


### PR DESCRIPTION
There is an issue with a div element in the webpage. This div is exceeding the width of the viewport, causing an unwanted horizontal scroll.

![Reproduction](https://github.com/danielroe/page-speed.dev/assets/26338224/172217a0-9420-4963-b2f7-9519d66ca9fe)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved the rendering of the progress ring by adjusting overflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->