### PR TITLE
fix for autocomplete DomainInput background color

### DIFF
--- a/components/TheDomainForm.vue
+++ b/components/TheDomainForm.vue
@@ -31,11 +31,19 @@ function navigateToNewDomain (event: Event) {
   <button v-if="domain && !editing" class="bg-transparent" @click="enableEditing">{{ domain }}</button>
   <form v-else class="flex flex-col gap-4 overflow-hidden" @submit.prevent="navigateToNewDomain">
     <input ref="input" name="domain" type="text"
-      class="md:-mt-1 rounded-none py-0 bg-transparent outline-none border-b-2 border-b-solid border-transparent focus:border-green-500 underline-dashed"
+      class="md:-mt-1 fix rounded-none py-0 bg-transparent outline-none border-b-2 border-b-solid border-transparent focus:border-green-500 underline-dashed"
       autofocus autocomplete="url" inputmode="url" autocapitalize="none" placeholder="enter a domain" required />
     <button type="submit"
       class="bg-green-400 text-black hover: hover:bg-white focus:bg-white active:bg-white text-xl md:text-2xl py-2 px-6 md:self-start">see
       results</button>
   </form>
 </template>
+
+<style>
+input:-webkit-autofill{
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: #ffffff;
+    caret-color: #ffffff;
+}
+</style>
 

--- a/components/TheDomainForm.vue
+++ b/components/TheDomainForm.vue
@@ -31,7 +31,7 @@ function navigateToNewDomain (event: Event) {
   <button v-if="domain && !editing" class="bg-transparent" @click="enableEditing">{{ domain }}</button>
   <form v-else class="flex flex-col gap-4 overflow-hidden" @submit.prevent="navigateToNewDomain">
     <input ref="input" name="domain" type="text"
-      class="md:-mt-1 fix rounded-none py-0 bg-transparent outline-none border-b-2 border-b-solid border-transparent focus:border-green-500 underline-dashed"
+      class="md:-mt-1 rounded-none py-0 bg-transparent outline-none border-b-2 border-b-solid border-transparent focus:border-green-500 underline-dashed"
       autofocus autocomplete="url" inputmode="url" autocapitalize="none" placeholder="enter a domain" required />
     <button type="submit"
       class="bg-green-400 text-black hover: hover:bg-white focus:bg-white active:bg-white text-xl md:text-2xl py-2 px-6 md:self-start">see
@@ -41,9 +41,9 @@ function navigateToNewDomain (event: Event) {
 
 <style>
 input:-webkit-autofill{
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: #ffffff;
-    caret-color: #ffffff;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: #ffffff;
+  caret-color: #ffffff;
 }
 </style>
 

--- a/components/TheDomainForm.vue
+++ b/components/TheDomainForm.vue
@@ -40,7 +40,7 @@ function navigateToNewDomain (event: Event) {
 </template>
 
 <style>
-input:-webkit-autofill{
+input:-webkit-autofill {
   -webkit-background-clip: text;
   -webkit-text-fill-color: #ffffff;
   caret-color: #ffffff;


### PR DESCRIPTION
Hi Daniel,

Do see that you did styling using uno - not sure best way to accomplish this in uno, hope this helps.

The fix is for when using an autocomplete value - the bg color of field is changed to white, have added a fix to keep it the same dark background - not sure what your thought are of this?


https://github.com/danielroe/page-speed.dev/assets/82201261/b6eefc63-c4fc-4455-91a8-5d91a2513e0c




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
	- Improved input field styling to handle autofill appearance.
	- Modified input element class attribute for enhanced styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->