### PR TITLE
fix footer not visible on some mobile browsers

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -127,7 +127,9 @@ else {
 </script>
 
 <template>
-  <div class="md:pl-[5vw] font-sans text-white min-h-dvh min-w-screen flex flex-col items-start justify-start">
+  <div
+    class="md:pl-[5vw] font-sans text-white min-h-screen min-h-dvh min-w-screen flex flex-col items-start justify-start"
+  >
     <div v-if="showConfetti" v-confetti />
     <div class="flex flex-col justify-start mt-4 sm:mt-8 md:my-12 p-4 gap-8 md:gap-12 flex-grow max-w-full">
       <div class="flex flex-row gap-4 text-white text-3xl md:text-5xl">

--- a/app.vue
+++ b/app.vue
@@ -127,9 +127,7 @@ else {
 </script>
 
 <template>
-  <div
-    class="md:pl-[5vw] font-sans text-white min-h-screen min-h-dvh min-w-screen flex flex-col items-start justify-start"
-  >
+  <div class="md:pl-[5vw] font-sans text-white min-h-screen min-h-dvh min-w-screen flex flex-col items-start justify-start">
     <div v-if="showConfetti" v-confetti />
     <div class="flex flex-col justify-start mt-4 sm:mt-8 md:my-12 p-4 gap-8 md:gap-12 flex-grow max-w-full">
       <div class="flex flex-row gap-4 text-white text-3xl md:text-5xl">

--- a/app.vue
+++ b/app.vue
@@ -127,7 +127,7 @@ else {
 </script>
 
 <template>
-  <div class="md:pl-[5vw] font-sans text-white min-h-screen min-w-screen flex flex-col items-start justify-start">
+  <div class="md:pl-[5vw] font-sans text-white min-h-dvh min-w-screen flex flex-col items-start justify-start">
     <div v-if="showConfetti" v-confetti />
     <div class="flex flex-col justify-start mt-4 sm:mt-8 md:my-12 p-4 gap-8 md:gap-12 flex-grow max-w-full">
       <div class="flex flex-row gap-4 text-white text-3xl md:text-5xl">

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -12,6 +12,11 @@ export default defineNuxtConfig({
     '@nuxtjs/plausible',
     '@nuxtjs/html-validator',
   ],
+  unocss: {
+    rules: [
+      ['min-h-screen', { 'min-height': '100vh' }, { layer: '_fallback' }],
+    ],
+  },
   htmlValidator: {
     failOnError: true,
   },


### PR DESCRIPTION
Hi Daniel,

Small fix to keep footer viewable when `vh` is dynamic. Here are some pics of issue on latest IOS (Safari and Chrome). Wasn't able to test on mobile device but should work - else we can use `svh`.

![IMG_C08015AA9584-1](https://github.com/danielroe/page-speed.dev/assets/82201261/90d955fb-4a12-429c-a95f-202ab86eb736)

![IMG_91BD38F650EE-1](https://github.com/danielroe/page-speed.dev/assets/82201261/24f38ec0-802d-45e2-b6f4-8804cd7d88ca)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
    - Updated the minimum height styling of the main app component for improved display on various devices.
    - Adjusted CSS class in the Vue component template for better layout aesthetics.
    - Added a new class attribute to the template section for enhanced styling effects.
    - Configured 'unocss' rules in Nuxt.js for specific styling requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->