### PR TITLE
only show "about these results" if results returned

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -169,7 +169,7 @@ else {
           v-if="crux || lighthouse" :domain="domain" :type="crux ? 'crux' : 'pagespeed-insights'"
           :timestamp="crux && cruxStatus !== 'pending' ? crux.timestamp : lighthouse && lighthouseStatus !== 'pending' ? lighthouse.timestamp : undefined"
         />
-        <details class="max-w-[500px] text-gray-400">
+        <details v-if="crux || lighthouse" class="max-w-[500px] text-gray-400">
           <summary class="cursor-pointer">
             about these results
           </summary>


### PR DESCRIPTION
Hi Daniel,

ATM even if you just type "test" (or any invalid domain) and you get the error message of "is this domain valid" it shows "about these results". This PR removes showing about results if no results are shown - just makes sense to me (unless the about these results were always there).

Keep it up!