### PR TITLE
DX - add reminder if google token not set

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -169,6 +169,9 @@ else {
           v-if="crux || lighthouse" :domain="domain" :type="crux ? 'crux' : 'pagespeed-insights'"
           :timestamp="crux && cruxStatus !== 'pending' ? crux.timestamp : lighthouse && lighthouseStatus !== 'pending' ? lighthouse.timestamp : undefined"
         />
+         <div class="max-w-[500px] text-gray-400" v-if="useRuntimeConfig().public.NUXT_GOOGLE_API_TOKEN === '' || useRuntimeConfig().public.NUXT_GOOGLE_API_TOKEN === undefined">
+        No Google API Token Provided. Please remember to set your Google API Token in your .env file (for development). To obtain a token visit <a class="underline" href="https://console.cloud.google.com/apis/credentials">here</a>
+        </div>
         <details class="max-w-[500px] text-gray-400">
           <summary class="cursor-pointer">
             about these results


### PR DESCRIPTION
Hi Daniel,

This is just an addition for DX if Google token is not set by dev.

Thoughts?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- A notification now appears to prompt the user to set a Google API token in the `.env` file if it's missing, enhancing the setup experience for development purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->