### PR TITLE
feat: add check to test final url when redirect present

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -35,6 +35,14 @@ if (import.meta.server) {
     await navigateTo(`/${validatedDomain}`)
 }
 
+if (import.meta.client) {
+  watch([crux, lighthouse], ([crux, lighthouse]) => {
+    const validatedDomain = crux?.domain || lighthouse?.domain
+    if (validatedDomain && validatedDomain !== domain.value)
+      navigateTo(`/${validatedDomain}`)
+  })
+}
+
 const keys = ['performance', 'accessibility', 'bestPractices', 'seo'] as const
 const showConfetti = computed(() => {
   // CWV fail, but ignore if there is now CrUX data

--- a/app.vue
+++ b/app.vue
@@ -29,6 +29,12 @@ watch(domain, () => {
   }
 })
 
+if (import.meta.server) {
+  const validatedDomain = crux.value?.domain || lighthouse.value?.domain
+  if (validatedDomain && validatedDomain !== domain.value)
+    await navigateTo(`/${validatedDomain}`)
+}
+
 const keys = ['performance', 'accessibility', 'bestPractices', 'seo'] as const
 const showConfetti = computed(() => {
   // CWV fail, but ignore if there is now CrUX data
@@ -127,7 +133,9 @@ else {
 </script>
 
 <template>
-  <div class="md:pl-[5vw] font-sans text-white min-h-screen min-h-dvh min-w-screen flex flex-col items-start justify-start">
+  <div
+    class="md:pl-[5vw] font-sans text-white min-h-screen min-h-dvh min-w-screen flex flex-col items-start justify-start"
+  >
     <div
       v-if="showConfetti"
       v-confetti
@@ -141,12 +149,6 @@ else {
         />
       </div>
       <template v-if="!editing && domain">
-        <span
-          v-if="(crux && crux.redirected) || (lighthouse && lighthouse.redirected)"
-          class="text-gray-400"
-        >
-          Showing results for {{ crux?.domain }} {{ lighthouse?.domain }}
-        </span>
         <template v-if="cruxStatus === 'pending' || lighthouseStatus === 'pending' || crux || lighthouse">
           <div class="flex flex-row flex-wrap gap-4 lg:flex-row justify-around w-full">
             <CoreWebVitals
@@ -213,7 +215,8 @@ else {
             <a
               class="underline hover:text-green-400 focus:text-green-400 active:text-green-400"
               href="https://developers.google.com/web/tools/lighthouse"
-            >Lighthouse</a> APIs to fetch and display Core Web
+            >Lighthouse</a> APIs to fetch and display Core
+            Web
             Vitals and PageSpeed Insights results.
           </p>
           <p class="mt-4">

--- a/app.vue
+++ b/app.vue
@@ -141,9 +141,12 @@ else {
         />
       </div>
       <template v-if="!editing && domain">
-        <span v-if="(crux && crux.redirected) || (lighthouse && lighthouse.redirected)" class="text-gray-400">
-            Showing results for {{ crux?.domain }} {{ lighthouse?.domain }}
-          </span>
+        <span
+          v-if="(crux && crux.redirected) || (lighthouse && lighthouse.redirected)"
+          class="text-gray-400"
+        >
+          Showing results for {{ crux?.domain }} {{ lighthouse?.domain }}
+        </span>
         <template v-if="cruxStatus === 'pending' || lighthouseStatus === 'pending' || crux || lighthouse">
           <div class="flex flex-row flex-wrap gap-4 lg:flex-row justify-around w-full">
             <CoreWebVitals

--- a/app.vue
+++ b/app.vue
@@ -135,6 +135,9 @@ else {
         <TheDomainForm v-model:editing="editing" :domain="domain" />
       </div>
       <template v-if="!editing && domain">
+        <span v-if="(crux && crux.redirected) || (lighthouse && lighthouse.redirected)" class="text-gray-400">
+            Showing results for {{ crux?.domain }} {{ lighthouse?.domain }}
+          </span>
         <template v-if="cruxStatus === 'pending' || lighthouseStatus === 'pending' || crux || lighthouse">
           <div class="flex flex-row flex-wrap gap-4 lg:flex-row justify-around w-full">
             <CoreWebVitals

--- a/server/api/crux/[domain].get.ts
+++ b/server/api/crux/[domain].get.ts
@@ -1,9 +1,25 @@
 const cwvKeys = ['largest_contentful_paint', 'cumulative_layout_shift', 'interaction_to_next_paint'] as const
 
 export default defineCachedEventHandler(async (event) => {
-  const domain = getRouterParam(event, 'domain')
+  let redirected = false
+  let domain = getRouterParam(event, 'domain')
   if (!domain || domain.includes('/') || domain.includes('%'))
     throw createError({ message: 'Invalid domain', statusCode: 422 })
+  try {
+    const response = await fetch(`https://${domain}`, { method: 'HEAD' })
+    if (response.redirected) {
+      // console.log(`Original URL: ${domain}`);
+      // console.log(`Final URL: ${response.url}`);
+      redirected = true
+      domain = response.url
+    }
+    else {
+      domain = `https://${domain}`
+    }
+  }
+  catch (error) {
+    throw createError({ message: 'Invalid domain', statusCode: 422 })
+  }
 
   try {
     const results = await $fetch<CrUXResult>(`/records:queryRecord`, {
@@ -13,12 +29,14 @@ export default defineCachedEventHandler(async (event) => {
         key: useRuntimeConfig().google.apiToken,
       },
       body: {
-        origin: `https://${domain}`,
+        origin: domain,
         formFactor: 'PHONE',
       },
     })
 
     return {
+      redirected,
+      domain,
       cwv: cwvKeys.every(key => Number(results.record.metrics[key].percentiles.p75) <= (Number(results.record.metrics[key].histogram[0].end || 0))),
       lcp: normalizeHistogram(results.record.metrics.largest_contentful_paint, { timeBased: true }),
       cls: normalizeHistogram(results.record.metrics.cumulative_layout_shift),

--- a/server/api/crux/[domain].get.ts
+++ b/server/api/crux/[domain].get.ts
@@ -2,7 +2,7 @@ const cwvKeys = ['largest_contentful_paint', 'cumulative_layout_shift', 'interac
 
 export default defineCachedEventHandler(async (event) => {
   const originalDomain = getRouterParam(event, 'domain')
-  const domain = await followRedirect(originalDomain)
+  const domain = await validateDomain(originalDomain)
 
   try {
     const results = await $fetch<CrUXResult>(`/records:queryRecord`, {

--- a/server/api/crux/[domain].get.ts
+++ b/server/api/crux/[domain].get.ts
@@ -1,8 +1,7 @@
 const cwvKeys = ['largest_contentful_paint', 'cumulative_layout_shift', 'interaction_to_next_paint'] as const
 
 export default defineCachedEventHandler(async (event) => {
-  const originalDomain = getRouterParam(event, 'domain')
-  const domain = await validateDomain(originalDomain)
+  const domain = await validateDomain(getRouterParam(event, 'domain'))
 
   try {
     const results = await $fetch<CrUXResult>(`/records:queryRecord`, {
@@ -18,7 +17,6 @@ export default defineCachedEventHandler(async (event) => {
     })
 
     return {
-      redirected: domain !== originalDomain,
       domain,
       cwv: cwvKeys.every(key => Number(results.record.metrics[key].percentiles.p75) <= (Number(results.record.metrics[key].histogram[0].end || 0))),
       lcp: normalizeHistogram(results.record.metrics.largest_contentful_paint, { timeBased: true }),

--- a/server/api/run/[domain].get.ts
+++ b/server/api/run/[domain].get.ts
@@ -1,30 +1,13 @@
 export default defineCachedEventHandler(async (event) => {
-  let redirected = false
-  let domain = getRouterParam(event, 'domain')
-  if (!domain || domain.includes('/') || domain.includes('%'))
-    throw createError({ message: 'Invalid domain', statusCode: 422 })
+  const originalDomain = getRouterParam(event, 'domain')
+  const domain = await followRedirect(originalDomain)
 
-  try {
-    const response = await fetch(`https://${domain}`, { method: 'HEAD' })
-    if (response.redirected) {
-      // console.log(`Original URL: ${domain}`);
-      // console.log(`Final URL: ${response.url}`);
-      redirected = true
-      domain = response.url
-    }
-    else {
-      domain = `https://${domain}`
-    }
-  }
-  catch (error) {
-    throw createError({ message: 'Invalid domain', statusCode: 422 })
-  }
   const token = useRuntimeConfig().google.apiToken
-  const results = await $fetch<PagespeedInsightsResult>(`/runPagespeed?url=${encodeURIComponent(domain)}&category=ACCESSIBILITY&category=BEST_PRACTICES&category=PERFORMANCE&category=SEO&strategy=mobile&key=${token}`, {
+  const results = await $fetch<PagespeedInsightsResult>(`/runPagespeed?url=${encodeURIComponent(`https://${domain}`)}&category=ACCESSIBILITY&category=BEST_PRACTICES&category=PERFORMANCE&category=SEO&strategy=mobile&key=${token}`, {
     baseURL: 'https://www.googleapis.com/pagespeedonline/v5',
   })
   return {
-    redirected,
+    redirected: domain !== originalDomain,
     domain,
     performance: results.lighthouseResult.categories.performance.score * 100,
     seo: results.lighthouseResult.categories.seo.score * 100,

--- a/server/api/run/[domain].get.ts
+++ b/server/api/run/[domain].get.ts
@@ -1,13 +1,11 @@
 export default defineCachedEventHandler(async (event) => {
-  const originalDomain = getRouterParam(event, 'domain')
-  const domain = await validateDomain(originalDomain)
+  const domain = await validateDomain(getRouterParam(event, 'domain'))
 
   const token = useRuntimeConfig().google.apiToken
   const results = await $fetch<PagespeedInsightsResult>(`/runPagespeed?url=${encodeURIComponent(`https://${domain}`)}&category=ACCESSIBILITY&category=BEST_PRACTICES&category=PERFORMANCE&category=SEO&strategy=mobile&key=${token}`, {
     baseURL: 'https://www.googleapis.com/pagespeedonline/v5',
   })
   return {
-    redirected: domain !== originalDomain,
     domain,
     performance: results.lighthouseResult.categories.performance.score * 100,
     seo: results.lighthouseResult.categories.seo.score * 100,

--- a/server/api/run/[domain].get.ts
+++ b/server/api/run/[domain].get.ts
@@ -1,6 +1,6 @@
 export default defineCachedEventHandler(async (event) => {
   const originalDomain = getRouterParam(event, 'domain')
-  const domain = await followRedirect(originalDomain)
+  const domain = await validateDomain(originalDomain)
 
   const token = useRuntimeConfig().google.apiToken
   const results = await $fetch<PagespeedInsightsResult>(`/runPagespeed?url=${encodeURIComponent(`https://${domain}`)}&category=ACCESSIBILITY&category=BEST_PRACTICES&category=PERFORMANCE&category=SEO&strategy=mobile&key=${token}`, {

--- a/server/utils/redirect.ts
+++ b/server/utils/redirect.ts
@@ -1,0 +1,21 @@
+import { parseURL } from 'ufo'
+
+export async function followRedirect(domain?: string) {
+  if (!domain || domain.includes('/') || domain.includes('%'))
+    throw createError({ message: 'Invalid domain', statusCode: 422 })
+
+  try {
+    const response = await fetch(`https://${domain}`, { method: 'HEAD' })
+    if (response.redirected) {
+      const host = parseURL(response.url).host
+      if (!host || !response.url.startsWith('https://')) {
+        throw createError({ message: 'Invalid domain redirect', statusCode: 422 })
+      }
+      return host
+    }
+    return domain
+  }
+  catch (error) {
+    throw createError({ message: 'Invalid domain', statusCode: 422 })
+  }
+}

--- a/server/utils/redirect.ts
+++ b/server/utils/redirect.ts
@@ -1,6 +1,6 @@
 import { parseURL } from 'ufo'
 
-export async function followRedirect(domain?: string) {
+export async function validateDomain(domain?: string) {
   if (!domain || domain.includes('/') || domain.includes('%'))
     throw createError({ message: 'Invalid domain', statusCode: 422 })
 


### PR DESCRIPTION
Hi @danielroe,

Intrested to get some good criticism and feedback.

To me biggest issue is that we shouldn't be checking domain redirect twice 🙈. (We can't move to front end because of cors, if was a way to implement in middleware would run twice I think 🤔..) and making it into a function. 

Also think we might need to update cache to be more efficient (in case where there is redirect).

Also, couldn't get it to work with $fetch, doesn't seem like it returns redirect like fetch - should I open an issue on ofetch - or is this on purpose. Could have done a manual if..else to check if final url was equal to inputted, though this was a better option. 

Not sure if you want to put the redirect message at the bottom with other info (else we need to move it closer to input field, didnt want to start adding slots in domain form or negative margins).

resolves https://github.com/danielroe/page-speed.dev/issues/9
Thanks for your work! 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved domain validation and navigation based on different environments for a better user experience.
	- Enhanced the template structure and text content related to Lighthouse APIs for Core Web Vitals and PageSpeed Insights.

- **Improvements**
	- Refactored domain validation logic in API endpoints to enhance code readability and maintainability.
	- Centralized domain validation logic to ensure proper domain validation before processing API calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->